### PR TITLE
Refactor: Replace framer-motion with motion/react in Button component

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,4 +1,4 @@
-import { MotionProps, motion } from "framer-motion";
+import { MotionProps, motion } from "motion/react";
 import React, { forwardRef, ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 


### PR DESCRIPTION
I've replaced the import of `framer-motion` with `motion/react` in the `components/common/Button.tsx` file.

This change standardizes the animation library used in your project, as other components were already using `motion/react`. The `MotionProps` type and the usage of `motion.button` were found to be compatible between the two libraries for the currently used properties, so no further changes to the component's animation logic were required.