### PR TITLE
Fix: Resolve TypeScript error in Button component

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -41,7 +41,21 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       className,
       disabled,
-      ...props
+      href, // Explicitly destructure href
+      // Destructure all potentially conflicting drag event props
+      onDrag,
+      onDragEnd,
+      onDragEnter,
+      onDragExit,
+      onDragLeave,
+      onDragOver,
+      onDragStart,
+      onDrop,
+      // Destructure animation event props
+      onAnimationStart,
+      onAnimationEnd,
+      onAnimationIteration,
+      ...buttonHTMLAttributes // Collect remaining HTML attributes
     },
     ref,
   ) => {
@@ -106,7 +120,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={combinedClasses}
         disabled={disabled || isLoading}
         {...motionProps}
-        {...props}
+        {...buttonHTMLAttributes} // Spread buttonHTMLAttributes
       >
         {isLoading && (
           <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
The Button component was passing all its props, including custom ones not recognized by HTML or Framer Motion, directly to the underlying `motion.button` element. This caused a TypeScript type error:

  Type '{ children: (false | Element)[]; href?: string | ... }'
  is not assignable to type 'Omit<HTMLMotionProps<"button">, "ref">'.

This commit resolves the issue by:
1. Separating the Button component's custom props (`variant`, `size`, `icon`, `iconPosition`, `isLoading`, `fullWidth`, `href`, `motionProps`) from standard HTML button attributes.
2. Ensuring only valid HTML attributes and `motionProps` are spread onto the `motion.button` element.
3. Explicitly destructuring potentially conflicting event handlers (drag and animation events) from the rest props to avoid type clashes between React's HTML attributes and MotionProps.

`pnpm tsc --noEmit` now passes without errors, confirming the fix.