### PR TITLE
Fix: Remove dynamic Tailwind class in CpuThinking component

### DIFF
--- a/app/reversi/components/CpuThinking.tsx
+++ b/app/reversi/components/CpuThinking.tsx
@@ -72,7 +72,6 @@ export default function CpuThinking({
       >
         <Brain
           size={24}
-          className={`text-${config.color}-400`}
           style={{ color: `var(--color-${config.color}-400)` }}
         />
 


### PR DESCRIPTION
Removes the dynamic `text-${config.color}-400` className from the Brain icon in the CpuThinking component. The styling is now solely handled by the inline style using the CSS variable `var(--color-${config.color}-400)` to prevent potential purging issues with Tailwind CSS.